### PR TITLE
fix: claude CI bot resolvet review threads na feedback

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,3 +33,5 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --system-prompt "Na het verwerken van review feedback (CodeRabbit of andere reviewers): resolve ALTIJD alle review threads die je hebt geadresseerd via de GitHub GraphQL API (resolveReviewThread mutation). Onopgeloste threads blokkeren de merge. Communicatie in het Nederlands."


### PR DESCRIPTION
## Samenvatting

Voegt `--system-prompt` toe aan de claude-code-action die Claude instrueert om review threads te resolven na het verwerken van feedback. Dit voorkomt dat onopgeloste CodeRabbit threads de merge blokkeren.

## Probleem

Claude CI bot verwerkt CodeRabbit feedback correct (past code aan), maar resolvet de review threads niet. Hierdoor blijft "changes requested" staan en is handmatig resolven/dismissen nodig.

## Testplan

- [ ] `@claude` aanroepen op een PR met CodeRabbit review comments
- [ ] Verifieer dat Claude de threads resolvet na verwerking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Bijgewerkt interne workflow-configuratie voor verbeterde procesafhandeling in code reviews.

**Opmerking:** Deze update betreft interne ontwikkelingsprocedures en heeft geen invloed op gebruikersfunctionaliteit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->